### PR TITLE
Address tech lead review for TCP session and client list docs.

### DIFF
--- a/src/TCP_server/include/session.h
+++ b/src/TCP_server/include/session.h
@@ -1,21 +1,23 @@
 #pragma once
 
 #include <boost/asio.hpp>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>
 
-// Обертка над одним TCP-клиентом: чтение команд и отправка бинарных сообщений.
+// Обертка над одним TCP-клиентом: чтение кадров как байтов и очередь отправки через async_write.
 class Session : public std::enable_shared_from_this<Session> {
 public:
-    using OnDataCallback = std::function<void(const std::vector<char>&, const std::shared_ptr<Session>&)>;
+    using OnDataCallback = std::function<void(const std::vector<std::uint8_t>&, const std::shared_ptr<Session>&)>;
     using OnDisconnectCallback = std::function<void(const std::shared_ptr<Session>&)>;
 
     Session(std::shared_ptr<boost::asio::ip::tcp::socket> socket);
     void Start();
     void Stop();
+    /// Enqueues bytes; actual socket I/O is performed by @c boost::asio::async_write in Write().
     void SendMsg(const std::vector<char>& message);
     bool IsOpen() const;
     void SetCallbacks(OnDataCallback on_data, OnDisconnectCallback on_disconnect);

--- a/src/TCP_server/include/tcpserver.h
+++ b/src/TCP_server/include/tcpserver.h
@@ -1,6 +1,9 @@
 #include "session.h"
 #include "../../client_list/client_list.h"
 
+#include <cstdint>
+#include <vector>
+
 #include <boost/asio.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <memory>
@@ -20,10 +23,10 @@ private:
     void DoAccept();
     std::shared_ptr<Session> OnAccept(std::shared_ptr<tcp::socket> socket,
                    const boost::system::error_code& error);
-    void HandleMessage(const std::vector<char>& message, const std::shared_ptr<Session>& session);
+    void HandleMessage(const std::vector<std::uint8_t>& frame, const std::shared_ptr<Session>& session);
     void HandleDisconnect(const std::shared_ptr<Session>& session);
     void ScheduleSnapshots();
-    ClientId ParseClientId(const std::vector<char>& message) const;
+    ClientId ParseClientId(const std::vector<std::uint8_t>& frame) const;
 
     boost::asio::io_context& io_context_;
     tcp::acceptor acceptor_;

--- a/src/TCP_server/src/session.cpp
+++ b/src/TCP_server/src/session.cpp
@@ -1,10 +1,12 @@
 #include "../include/session.h"
 
+#include <memory>
 #include <utility>
 
 using namespace boost::asio::ip;
 
-// Реализация асинхронного цикла: read_until('\n') для команд и async_write для ответов/снэпшотов.
+// Чтение: async_read_until по '\n' (разделитель кадра), данные в колбэк как std::vector<std::uint8_t>.
+// Отправка: постановка в очередь под mutex, старт цепочки async_write через dispatch на executor сокета.
 Session::Session(std::shared_ptr<tcp::socket> socket)
     : socket_(std::move(socket)) {}
 
@@ -32,7 +34,6 @@ void Session::Read() {
 }
 
 void Session::ProcessRead(const boost::system::error_code& error, std::size_t bytes_transferred) {
-    (void)bytes_transferred;
     if (error) {
         if (on_disconnect_) {
             on_disconnect_(shared_from_this());
@@ -40,32 +41,39 @@ void Session::ProcessRead(const boost::system::error_code& error, std::size_t by
         return;
     }
 
-    std::vector<char> data(bytes_transferred);
-    boost::asio::buffer_copy(boost::asio::buffer(data), read_buffer_.data(), bytes_transferred);
+    std::vector<std::uint8_t> frame(bytes_transferred);
+    if (bytes_transferred > 0) {
+        boost::asio::buffer_copy(boost::asio::buffer(frame), read_buffer_.data(), bytes_transferred);
+    }
     read_buffer_.consume(bytes_transferred);
+
     if (on_data_) {
-        on_data_(data, shared_from_this());
+        on_data_(frame, shared_from_this());
     }
     Read();
 }
 
 void Session::SendMsg(const std::vector<char>& message) {
-    if (!socket_ || !socket_->is_open()) {
+    if (!socket_) {
         return;
     }
 
-    bool start_writing = false;
-    {
-        std::lock_guard<std::mutex> lock(write_mutex_);
-        // Переход очереди из пустой в непустую защищен write_mutex_,
-        // поэтому локальному флагу не нужна атомарность.
-        start_writing = messages_queue_.empty();
-        messages_queue_.push_back(message);
-    }
-
-    if (start_writing) {
-        Write();
-    }
+    auto self = shared_from_this();
+    auto payload = std::make_shared<std::vector<char>>(message);
+    boost::asio::dispatch(socket_->get_executor(), [this, self, payload]() {
+        if (!socket_ || !socket_->is_open()) {
+            return;
+        }
+        bool start_chain = false;
+        {
+            std::lock_guard<std::mutex> lock(write_mutex_);
+            start_chain = messages_queue_.empty();
+            messages_queue_.push_back(std::move(*payload));
+        }
+        if (start_chain) {
+            Write();
+        }
+    });
 }
 
 bool Session::IsOpen() const {

--- a/src/TCP_server/src/tcpserver.cpp
+++ b/src/TCP_server/src/tcpserver.cpp
@@ -1,9 +1,8 @@
 #include "../include/tcpserver.h"
 
-#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <iostream>
-#include <sstream>
 
 // Сервер принимает HELLO <client_id>, обновляет client_list и шлет периодические snapshot.
 TCPServer::TCPServer(boost::asio::io_context& io_context, unsigned short port)
@@ -53,7 +52,9 @@ std::shared_ptr<Session> TCPServer::OnAccept(std::shared_ptr<tcp::socket> socket
 
     auto session = std::make_shared<Session>(std::move(socket));
     session->SetCallbacks(
-        [this](const std::vector<char>& message, const std::shared_ptr<Session>& s) { HandleMessage(message, s); },
+        [this](const std::vector<std::uint8_t>& frame, const std::shared_ptr<Session>& s) {
+            HandleMessage(frame, s);
+        },
         [this](const std::shared_ptr<Session>& s) { HandleDisconnect(s); });
     session->Start();
     return session;
@@ -64,8 +65,8 @@ void TCPServer::SendUpdateMessage(const std::string& message) {
     client_list_->broadcast_to_subscribed(payload);
 }
 
-void TCPServer::HandleMessage(const std::vector<char>& message, const std::shared_ptr<Session>& session) {
-    const ClientId client_id = ParseClientId(message);
+void TCPServer::HandleMessage(const std::vector<std::uint8_t>& frame, const std::shared_ptr<Session>& session) {
+    const ClientId client_id = ParseClientId(frame);
     if (client_id == 0) {
         const std::string response = "ERR expected `HELLO <client_id>`\n";
         session->SendMsg(std::vector<char>(response.begin(), response.end()));
@@ -114,19 +115,41 @@ void TCPServer::ScheduleSnapshots() {
     });
 }
 
-ClientId TCPServer::ParseClientId(const std::vector<char>& message) const {
-    std::string line(message.begin(), message.end());
-    line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
-    line.erase(std::remove(line.begin(), line.end(), '\n'), line.end());
-
-    std::istringstream iss(line);
-    std::string cmd;
-    ClientId id = 0;
-    if (!(iss >> cmd >> id)) {
+ClientId TCPServer::ParseClientId(const std::vector<std::uint8_t>& frame) const {
+    if (frame.empty()) {
         return 0;
     }
-    if (cmd != "HELLO") {
+    std::size_t end = frame.size();
+    while (end > 0 && (frame[end - 1] == '\n' || frame[end - 1] == '\r' || frame[end - 1] == ' ')) {
+        --end;
+    }
+    std::size_t beg = 0;
+    while (beg < end && frame[beg] == ' ') {
+        ++beg;
+    }
+    if (beg >= end) {
         return 0;
+    }
+    static constexpr char kHello[] = "HELLO";
+    constexpr std::size_t kHelloLen = sizeof(kHello) - 1;
+    if (end - beg < kHelloLen + 2) {
+        return 0;
+    }
+    for (std::size_t i = 0; i < kHelloLen; ++i) {
+        if (frame[beg + i] != static_cast<std::uint8_t>(kHello[i])) {
+            return 0;
+        }
+    }
+    if (frame[beg + kHelloLen] != ' ') {
+        return 0;
+    }
+    ClientId id = 0;
+    for (std::size_t i = beg + kHelloLen + 1; i < end; ++i) {
+        const auto c = frame[i];
+        if (c < '0' || c > '9') {
+            return 0;
+        }
+        id = id * 10 + static_cast<ClientId>(c - '0');
     }
     return id;
 }

--- a/src/client_list/client_list.h
+++ b/src/client_list/client_list.h
@@ -31,9 +31,17 @@ public:
     virtual std::vector<std::shared_ptr<Order>> get_asks(ClientId id) const = 0;
     virtual const std::vector<std::shared_ptr<Order>>& get_asks_ref(ClientId id) const = 0;
     virtual bool is_subscribed(ClientId id) const = 0;
-    /** Пометить клиента как подписанного на рассылку снэпшотов. */
+    /**
+     * @brief Subscribes a client to snapshot broadcasts.
+     * @param id Client identifier.
+     * @note Помечает клиента как подписанного на рассылку снэпшотов (без неявного создания записи).
+     */
     virtual void subscribe(ClientId id) = 0;
-    /** Пометить клиента как отписанного от рассылки снэпшотов. */
+    /**
+     * @brief Unsubscribes a client from snapshot broadcasts.
+     * @param id Client identifier.
+     * @note Помечает клиента как отписанного от рассылки снэпшотов.
+     */
     virtual void unsubscribe(ClientId id) = 0;
     /** Вернуть идентификаторы клиентов, которым надо отправлять снэпшоты. */
     virtual std::vector<ClientId> get_subscribed_clients() const = 0;


### PR DESCRIPTION
Восстановил поддержку Doxygen для подписки/отписки, передавать прочитанные кадры в виде байтов, анализировать HELLO без строковых потоков и ставить исходящие данные в очередь исполнителя сокета перед async_write.