### PR TITLE
I-019-add-msg-type (task 3.12)

### DIFF
--- a/bid_ask_snaphot_interface/bid_ask_interface.h
+++ b/bid_ask_snaphot_interface/bid_ask_interface.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <sstream>
@@ -8,8 +9,10 @@
 
 namespace common {
 constexpr uint8_t topN = 20;
+constexpr size_t kPtrForMsgType = 0;
+constexpr size_t kByteForMsgType = 1;
 
-///delimeter for cast order price to double
+/// delimeter for cast order price to double
 static const double PRICE_DELIMETER = 100;
 
 using ID = uint64_t;
@@ -77,20 +80,28 @@ struct Snapshot {
 };
 
 std::vector<char> Snapshot::serialize() const {
-    size_t size = sizeof(Snapshot);
+    size_t size = sizeof(Snapshot) + kByteForMsgType;
     std::vector<char> buffer(size);
-    std::memcpy(buffer.data(), &topBids, sizeof(topBids));
-    std::memcpy(buffer.data() + sizeof(topBids), &topAsks, sizeof(topAsks));
+    /** @todo translate to enum */
+    int msg_type = 0;
+    buffer[kPtrForMsgType] = static_cast<char>(msg_type);
+
+    char* ptr_for_msg_data = buffer.data() + kByteForMsgType;
+    std::memcpy(ptr_for_msg_data, &topBids, sizeof(topBids));
+    std::memcpy(ptr_for_msg_data + sizeof(topBids), &topAsks, sizeof(topAsks));
+
     return buffer;
 }
 
+/** @todo do fn GetMassageType() when enum appears */
 Snapshot Snapshot::deserialize(const std::vector<char>& data) {
-    if (data.size() != sizeof(Snapshot)) {
+    if (data.size() != sizeof(Snapshot) + kByteForMsgType) {
         throw std::runtime_error("Deserialization error: incorrect data size");
     }
     Snapshot result;
-    std::memcpy(&result.topBids, data.data(), sizeof(topBids));
-    std::memcpy(&result.topAsks, data.data() + sizeof(topBids), sizeof(topAsks));
+    const char* ptr_for_msg_data = data.data() + kByteForMsgType;
+    std::memcpy(&result.topBids, ptr_for_msg_data, sizeof(topBids));
+    std::memcpy(&result.topAsks, ptr_for_msg_data + sizeof(topBids), sizeof(topAsks));
     return result;
 }
 
@@ -131,4 +142,4 @@ std::array<double, topN> Snapshot::get_ask_prices() const {
 bool operator==(const Snapshot& lhs, const Snapshot& rhs) {
     return lhs.topBids == rhs.topBids && lhs.topAsks == rhs.topAsks;
 }
-}  /// namespace common
+}  // namespace common

--- a/bid_ask_snaphot_interface/tests.cpp
+++ b/bid_ask_snaphot_interface/tests.cpp
@@ -1,18 +1,21 @@
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include "inc.h"
+#include "bid_ask_interface.h"
 
 TEST_CASE("Order") {
     SECTION("Get price empty order") {
         common::Order o1;
-        auto price1 = o1.get_price();
-        REQUIRE(price1 == 0);
+        auto price1_dispay = o1.get_price();
+        REQUIRE(o1.price == 0);
+        REQUIRE(price1_dispay == Catch::Approx(0.00 / common::PRICE_DELIMETER));
     }
 
     SECTION("Get price order") {
         common::Order o2(1, 2, 3);
-        auto price2 = o2.get_price();
-        REQUIRE(price2 == 2);
+        auto price2_dispay = o2.get_price();
+        REQUIRE(o2.price == 2);
+        REQUIRE(price2_dispay == Catch::Approx(2.00 / common::PRICE_DELIMETER));
     }
 }
 
@@ -20,7 +23,7 @@ TEST_CASE("Snapshot serialize") {
     SECTION("Empty snapshot") {
         common::Snapshot empty_snap;
         auto serialize_snap = empty_snap.serialize();
-        REQUIRE(serialize_snap.size() == sizeof(common::Snapshot));
+        REQUIRE(serialize_snap.size() == sizeof(common::Snapshot) + common::kByteForMsgType);
 
         common::Snapshot result_snap = common::Snapshot::deserialize(serialize_snap);
         REQUIRE(empty_snap == result_snap);
@@ -34,7 +37,7 @@ TEST_CASE("Snapshot serialize") {
         }
         auto serialize_snap = snap.serialize();
 
-        REQUIRE(serialize_snap.size() == sizeof(common::Snapshot));
+        REQUIRE(serialize_snap.size() == sizeof(common::Snapshot) + common::kByteForMsgType);
 
         common::Snapshot result_snap = common::Snapshot::deserialize(serialize_snap);
 


### PR DESCRIPTION
# Add message type
Add a message type to the snapshot serialization
### What’s Done
- Added message type to snapshot serialization.
- left todo before enum creation.
### Build
*It doesn't assemble because there are problems with the overall assembly
